### PR TITLE
Optimize common code

### DIFF
--- a/static/auth/check_in.html
+++ b/static/auth/check_in.html
@@ -6,6 +6,7 @@
 </head>
 <body>
 <div id="app-root"></div>
+<script src="/bundle/common.js"></script>
 <script src="/bundle/check_in.bundle.js"></script>
 </body>
 </html>

--- a/static/auth/login.html
+++ b/static/auth/login.html
@@ -11,6 +11,7 @@
 	<input type="submit">
 </form>
 <div id="error-message"></div>
+<script src="/bundle/common.js"></script>
 <script src="/bundle/login.bundle.js"></script>
 </body>
 </html>

--- a/static/index.html
+++ b/static/index.html
@@ -6,6 +6,7 @@
 </head>
 <body>
     <div id="app-root"></div>
+    <script src="/bundle/common.js"></script>
     <script src="/bundle/index.bundle.js"></script>
 </body>
 </html>

--- a/static/screen.html
+++ b/static/screen.html
@@ -6,6 +6,7 @@
 </head>
 <body>
     <div id="app-root"></div>
+    <script src="/bundle/common.js"></script>
     <script src="/bundle/screen.bundle.js"></script>
 </body>
 </html>

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -7,6 +7,7 @@ var DEBUG = !process.argv.includes('--release');
 var plugins = [
   new webpack.optimize.OccurenceOrderPlugin(),
   new webpack.DefinePlugin({'process.env.NODE_ENV': '"' + (process.env.NODE_ENV || (DEBUG ? 'development' : 'production')) + '"'}),
+  new webpack.optimize.CommonsChunkPlugin('common.js'),
 ];
 
 if (!DEBUG) {


### PR DESCRIPTION
WebpackのCommonsChunkPluginを利用し、各ページ共通のコードを1つのファイルにまとめるようにした。
これによって `npm run release` が 5～10秒ほど早くなった模様。
